### PR TITLE
EN-2 add env example

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# the environment variables you need to set
+DATABASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel


### PR DESCRIPTION
EN-2 add env example

best practice so that new developers to the project know what environment variables to look for without consulting a readme or reverse engineering, saves time with onboarding